### PR TITLE
Removed final to be able to mock PausableTimer.

### DIFF
--- a/lib/pausable_timer.dart
+++ b/lib/pausable_timer.dart
@@ -10,7 +10,7 @@ import 'package:clock/clock.dart' show clock;
 ///
 /// This implementation is roughly based on
 /// [this comment](https://github.com/dart-lang/sdk/issues/43329#issuecomment-687024252).
-final class PausableTimer implements Timer {
+class PausableTimer implements Timer {
   /// The [Zone] where the [_callback] will be run.
   ///
   /// Dart generally calls asynchronous callbacks in the zone where they were


### PR DESCRIPTION
Removed the final modifier from PausableTimer, allowing the class to be mocked in tests. For additional context, see https://github.com/dart-lang/mockito/issues/635